### PR TITLE
POC: generation of launcher script instead of long command line

### DIFF
--- a/bin/seacan
+++ b/bin/seacan
@@ -91,29 +91,47 @@ package App::Seacan {
         system("rsync", "-8vPa", $source_directory, $target_directory) == 0 or die;
     }
 
-	sub create_launcher {
-        my $self = shift;
-		my $output = $self->config->{seacan}{output};
-        my $target_directory = join_path($output, 'app', 'bin');
-		# This is a hack to determine the application name
-		# Maybe the application name could be part of the configuration
-		my $app_name = $output;
-		$app_name = s/.+?\/*(.+)$/$1/;
-		my $launcher = join_path($target_directory, $app_name);
-		make_path($target_directory);
-		open(my $fh, ">:utf8", $launcher) or die $!;
-		print $fh "#!/bin/env bash\n";
-		print $fh "PERL5LIB=$output/local/lib/perl5\n";
-		print $fh "export PERL5LIB\n";
-		# This shouldn't be hardcoded and be part of the config
-		print $fh "$output/perlbrew/perls/seacan-perl/bin/perl $output/app/$app_name/bin/app.pl\n";
-	}
+    sub create_launcher {
+	# Instead of giving a very long command to the user
+	# a launcher script is generated.
+	# app_name and main_script could be added to the configuration
+	# so we can add the info directly instead of "guessing" it
+	# through a regex.
+
+    	my $self = shift;
+	my $output = $self->config->{seacan}{output};
+	
+	# The launcher script goes into bin of the target directory
+        my $target_directory = join_path($output, 'bin');
+
+	# This is a hack to determine the application name from the
+	# output value of the config
+	my $app_name = $output;
+	$app_name =~ s/^.+\/(.+?)$/$1/;
+
+	# Apps following the CPAN guidelines have a lib directory with the
+	# modules. Adding this to the PERL5LIB allows to run this distributions
+	# without installing them.
+	my $app_lib =  join_path($output, 'app', $app_name, 'lib');
+	my $launcher = join_path($target_directory, $app_name);
+	make_path($target_directory);
+	open(my $fh, ">:utf8", $launcher) or die $!;
+	print $fh "#!/bin/bash\n";
+	print $fh "PERL5LIB=$output/local/lib/perl5:$app_lib\n";
+	print $fh "export PERL5LIB\n";
+	# String "app" shouldn't be hardcoded and be part of the config
+	# app.pl will not be the likely name of the main script.
+	print $fh "$output/perlbrew/perls/seacan/bin/perl $output/app/$app_name/bin/app.pl\n";
+	close $fh or die($!);
+	chmod(0755, $launcher) or die($!);
+   }
 
     sub run {
         my $self = shift;
         $self->install_perl unless $self->perl_is_installed;
         $self->install_cpan;
         $self->copy_app;
+	$self->create_launcher;
     }
 };
 


### PR DESCRIPTION
Instead of giving a very long command to the user a launcher script is generated. 'app_name' and 'main_script' could be added to the configuration so we can add the info directly instead of "guessing" it through a regex.

Just an idea...

C.
