### PR TITLE
Various cleanups

### DIFF
--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -10,7 +10,6 @@ our $VERSION = "0.1.0";
 
 use English qw<-no_match_vars>;
 use Mo qw<required coerce>;
-use File::Path qw<make_path>;
 use TOML qw<from_toml>;
 use Path::Tiny qw<path>;
 

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -39,9 +39,10 @@ sub seacan_perl {
 
 sub perl_is_installed {
     my $self = shift;
-    my $perlbrew_root_path = path($self->config->{seacan}{output}, "perlbrew")->stringify;
-    return 0 unless -d $perlbrew_root_path;
-    my $perl_executable = path($perlbrew_root_path, "perls", $self->config->{perl}{installed_as}, "bin", "perl")->stringify;
+    my $perlbrew_root_path = path($self->config->{seacan}{output}, "perlbrew");
+    $perlbrew_root_path->is_dir
+        or return 0;
+    my $perl_executable = $perlbrew_root_path->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" )->stringify;
     if (my $r = -f $perl_executable) {
         say STDERR "perl is installed: $perl_executable";
         return 1;

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -34,7 +34,7 @@ sub seacan_perlbrew_root {
 
 sub seacan_perl {
     my $self = shift;
-    return $self->seacan_perlbrew_root->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" )->stringify;
+    return $self->seacan_perlbrew_root->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" );
 }
 
 sub perl_is_installed {

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -1,6 +1,7 @@
 package App::Seacan;
 use strict;
 use warnings;
+use constant { 'EXEC_MODE' => '0755' };
 
 # Semantic Vesioning: http://semver.org/
 # Not sure if I want to use v-string, but I do want to follow
@@ -148,16 +149,20 @@ sub create_launcher {
     # without installing them.
     my $launcher = path($target_directory, $app_name)->stringify;
     make_path($target_directory);
-    open(my $fh, '>:encoding(UTF-8)', $launcher) or die $!;
-    print $fh "#!/bin/bash\n";
-    print $fh 'CURRDIR=$(dirname $(readlink -f $0))', "\n";
-    print $fh "PERL5LIB=\$CURRDIR/../local/lib/perl5:\$CURRDIR/../app/$app_name/lib\n";
-    print $fh "export PERL5LIB\n";
-    # String "app" shouldn't be hardcoded and be part of the config
-    # app.pl will not be the likely name of the main script.
-    print $fh "\$CURRDIR/../perlbrew/perls/seacan/bin/perl \$CURRDIR/../app/$app_name/bin/$app_name \$@\n";
-    close $fh or die($!);
-    chmod(0755, $launcher) or die($!);
+    my $launcher_path = path($luncher);
+
+    $launcher_path->spew_utf8(
+        "#!/bin/bash\n",
+        'CURRDIR=$(dirname $(readlink -f $0))' . "\n",
+        "PERL5LIB=\$CURRDIR/../local/lib/perl5:\$CURRDIR/../app/$app_name/lib\n",
+        "export PERL5LIB\n",
+
+        # String "app" shouldn't be hardcoded and be part of the config
+        # app.pl will not be the likely name of the main script.
+        "\$CURRDIR/../perlbrew/perls/seacan/bin/perl \$CURRDIR/../app/$app_name/bin/$app_name \$@\n",
+    );
+
+    $launcher_path->chmod( EXEC_MODE() );
 }
 
 sub run {

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -17,9 +17,7 @@ has config => (
     coerce => sub {
         my $c = $_[0];
         if (!ref($c) && -f $c) {
-            open(my $fh, '<:encoding(UTF-8)', $c) or die $!;
-            local $/ = undef;
-            $c = from_toml( scalar <$fh> );
+            $c = from_toml( path($c)->slurp_utf8 );
         }
         $c->{perl}{installed_as} //= "seacan";
 

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -42,11 +42,13 @@ sub perl_is_installed {
     my $perlbrew_root_path = path($self->config->{seacan}{output}, "perlbrew");
     $perlbrew_root_path->is_dir
         or return 0;
-    my $perl_executable = $perlbrew_root_path->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" )->stringify;
-    if (my $r = -f $perl_executable) {
+    my $perl_executable = $perlbrew_root_path->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" );
+
+    if ( $perl_executable->is_file ) {
         say STDERR "perl is installed: $perl_executable";
         return 1;
     }
+
     return 0;
 }
 

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -99,7 +99,7 @@ sub install_perl {
 
 sub install_cpan {
     my $self = shift;
-    my $cpanm_command = $self->seacan_perlbrew_root->child( "bin", "cpanm")->stringify;
+    my $cpanm_command = $self->seacan_perlbrew_root->child( "bin", "cpanm");
     my $perl_command = $self->seacan_perl;
 
     local $OUTPUT_FIELD_SEPARATOR = q{ };

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -39,13 +39,22 @@ sub seacan_perl {
 
 sub perl_is_installed {
     my $self = shift;
-    my $perlbrew_root_path = path($self->config->{seacan}{output}, "perlbrew");
+
+    my $perlbrew_root_path
+        = path( $self->config->{seacan}{output}, 'perlbrew' );
+
     $perlbrew_root_path->is_dir
         or return 0;
-    my $perl_executable = $perlbrew_root_path->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" );
+
+    my $perl_executable = $perlbrew_root_path->child(
+        'perls',
+        $self->config->{perl}{installed_as},
+        'bin',
+        'perl',
+    );
 
     if ( $perl_executable->is_file ) {
-        say STDERR "perl is installed: $perl_executable";
+        print STDERR "perl is installed: $perl_executable\n";
         return 1;
     }
 

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -29,12 +29,12 @@ has config => (
 
 sub seacan_perlbrew_root {
     my $self = shift;
-    return path($self->config->{seacan}{output}, "perlbrew")->stringify;
+    return path($self->config->{seacan}{output}, "perlbrew");
 }
 
 sub seacan_perl {
     my $self = shift;
-    return path( $self->seacan_perlbrew_root, "perls", $self->config->{perl}{installed_as}, "bin", "perl" )->stringify;
+    return $self->seacan_perlbrew_root->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" )->stringify;
 }
 
 sub perl_is_installed {
@@ -99,7 +99,7 @@ sub install_perl {
 
 sub install_cpan {
     my $self = shift;
-    my $cpanm_command = path( $self->seacan_perlbrew_root, "bin", "cpanm")->stringify;
+    my $cpanm_command = $self->seacan_perlbrew_root->child( "bin", "cpanm")->stringify;
     my $perl_command = $self->seacan_perl;
 
     local $OUTPUT_FIELD_SEPARATOR = q{ };

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -130,10 +130,10 @@ sub install_cpan {
 
 sub copy_app {
     my $self = shift;
-    my $target_directory = path($self->config->{seacan}{output}, "app", $self->config->{seacan}{app_name})->stringify;
+    my $target_directory = path($self->config->{seacan}{output}, "app", $self->config->{seacan}{app_name});
     my $source_directory = $self->config->{seacan}{app};
 
-    make_path($target_directory);
+    $target_directory->mkpath();
 
     unless ( $source_directory =~ m{/$} ) {
         # this is telling rsync to copy the contents of $source_directory

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -15,7 +15,7 @@ has config => (
     coerce => sub {
         my $c = $_[0];
         if (!ref($c) && -f $c) {
-            open(my $fh, "<:utf8", $c) or die $!;
+            open(my $fh, '<:encoding(UTF-8)', $c) or die $!;
             local $/ = undef;
             $c = from_toml( scalar <$fh> );
         }
@@ -147,7 +147,7 @@ sub create_launcher {
     # without installing them.
     my $launcher = path($target_directory, $app_name)->stringify;
     make_path($target_directory);
-    open(my $fh, ">:utf8", $launcher) or die $!;
+    open(my $fh, '>:encoding(UTF-8)', $launcher) or die $!;
     print $fh "#!/bin/bash\n";
     print $fh 'CURRDIR=$(dirname $(readlink -f $0))', "\n";
     print $fh "PERL5LIB=\$CURRDIR/../local/lib/perl5:\$CURRDIR/../app/$app_name/lib\n";

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -155,7 +155,7 @@ sub create_launcher {
     my $output = $self->config->{seacan}{output};
 
     # The launcher script goes into bin of the target directory
-    my $target_directory = path($output, 'bin')->stringify;
+    my $target_directory = path($output, 'bin');
 
     my $app_name = $self->config->{seacan}{app_name};
     if ( !$app_name ) {
@@ -169,9 +169,8 @@ sub create_launcher {
     # Apps following the CPAN guidelines have a lib directory with the
     # modules. Adding this to the PERL5LIB allows to run this distributions
     # without installing them.
-    my $launcher = path($target_directory, $app_name)->stringify;
-    make_path($target_directory);
-    my $launcher_path = path($luncher);
+    my $launcher_path = $target_directory->child($app_name);
+    $target_directory->mkpath();
 
     $launcher_path->spew_utf8(
         "#!/bin/bash\n",

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -103,7 +103,7 @@ sub install_cpan {
     my $perl_command = $self->seacan_perl;
 
     local $OUTPUT_FIELD_SEPARATOR = q{ };
-    system($perl_command, $cpanm_command, "--notest", "-L", path($self->config->{seacan}{output}, "local")->stringify, "--installdeps", $self->config->{seacan}{app} ) == 0 or die $!;
+    system($perl_command, $cpanm_command, "--notest", "-L", path($self->config->{seacan}{output}, "local"), "--installdeps", $self->config->{seacan}{app} ) == 0 or die $!;
 }
 
 sub copy_app {

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -72,7 +72,10 @@ sub install_perl {
     my $self = shift;
 
     my $perlbrew_root_path = $self->seacan_perlbrew_root;
-    make_path( $perlbrew_root_path ) unless -d $perlbrew_root_path;
+
+    # FIXME: Shouldn't this use 'safe' => 0 ?
+    $perlbrew_root_path->is_dir
+        or $perlbrew_root_path->mkpath();
 
     for (keys %ENV) {
         delete $ENV{$_} if /\APERLBREW_/;

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -1,4 +1,6 @@
 package App::Seacan;
+use strict;
+use warnings;
 
 # Semantic Vesioning: http://semver.org/
 # Not sure if I want to use v-string, but I do want to follow

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -7,6 +7,7 @@ use warnings;
 # semvar as a convention.
 our $VERSION = "0.1.0";
 
+use English qw<-no_match_vars>;
 use Mo qw<required coerce>;
 use File::Path qw<make_path>;
 use TOML qw<from_toml>;
@@ -100,7 +101,7 @@ sub install_cpan {
     my $cpanm_command = path( $self->seacan_perlbrew_root, "bin", "cpanm")->stringify;
     my $perl_command = $self->seacan_perl;
 
-    $, = " ";
+    local $OUTPUT_FIELD_SEPARATOR = q{ };
     system($perl_command, $cpanm_command, "--notest", "-L", path($self->config->{seacan}{output}, "local")->stringify, "--installdeps", $self->config->{seacan}{app} ) == 0 or die $!;
 }
 

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -16,11 +16,13 @@ use Path::Tiny qw<path>;
 
 has config => (
     required => 1,
-    coerce => sub {
+    coerce   => sub {
         my $c = $_[0];
-        if (!ref($c) && -f $c) {
+
+        if ( !ref($c) && -f $c ) {
             $c = from_toml( path($c)->slurp_utf8 );
         }
+
         $c->{perl}{installed_as} //= "seacan";
 
         return $c;

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -88,7 +88,7 @@ sub install_perl {
     $ENV{PERLBREW_ROOT} = $perlbrew_root_path;
 
     system("curl -L https://install.perlbrew.pl | bash") == 0 or die $!;
-    my $perlbrew_command = path($perlbrew_root_path, "bin", "perlbrew")->stringify;
+    my $perlbrew_command = path($perlbrew_root_path, "bin", "perlbrew");
 
     my @perl_install_cmd = (
         $perlbrew_command,

--- a/lib/App/Seacan.pm
+++ b/lib/App/Seacan.pm
@@ -34,7 +34,12 @@ sub seacan_perlbrew_root {
 
 sub seacan_perl {
     my $self = shift;
-    return $self->seacan_perlbrew_root->child( "perls", $self->config->{perl}{installed_as}, "bin", "perl" );
+    return $self->seacan_perlbrew_root->child(
+        'perls',
+        $self->config->{perl}{installed_as},
+        'bin',
+        'perl',
+   );
 }
 
 sub perl_is_installed {


### PR DESCRIPTION
The following is a list f very small commits which clean up a bunch of stuff.

Here's a summary:
* Use [Path::Tiny](https://metacpan.org/pod/Path::Tiny). Since this can be fatpacked, why not use shiny stuff?
* At first corrected the UTF-8 layer, then the move to `Path::Tiny` cleared it entirely.
* Use `English` for variable name, localize.
* Some spacing and indentation.